### PR TITLE
Statically link mingw binaries for Windows build

### DIFF
--- a/native-agent/CMakeLists.txt
+++ b/native-agent/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-everything -std=c++11")
 
 include_directories(src/main/headers)
 if(WIN32)
+    # Linking mingw libs statically
+    set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ ${CMAKE_CSS_STANDARD_LIBRARIES}")
     include_directories(src/main/headers/win32)
 endif()
 if(APPLE)


### PR DESCRIPTION
Statically link mingw binaries for Windows library.

Fixes https://github.com/reactor/BlockHound/pull/16#issuecomment-475625391
