### PR TITLE
Change the top-level package to `reactor.blockhound`.

### DIFF
--- a/agent/src/main/java/reactor/blockhound/ASMClassFileTransformer.java
+++ b/agent/src/main/java/reactor/blockhound/ASMClassFileTransformer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package reactor;
+package reactor.blockhound;
 
 import org.objectweb.asm.*;
 import org.objectweb.asm.commons.GeneratorAdapter;

--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package reactor;
+package reactor.blockhound;
 
 import net.bytebuddy.agent.ByteBuddyAgent;
 import reactor.blockhound.integration.BlockHoundIntegration;

--- a/agent/src/main/java/reactor/blockhound/BlockHoundRuntime.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHoundRuntime.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package reactor;
+package reactor.blockhound;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;

--- a/agent/src/main/java/reactor/blockhound/BlockingMethod.java
+++ b/agent/src/main/java/reactor/blockhound/BlockingMethod.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package reactor;
+package reactor.blockhound;
 
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 

--- a/agent/src/main/java/reactor/blockhound/InstrumentationUtils.java
+++ b/agent/src/main/java/reactor/blockhound/InstrumentationUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package reactor;
+package reactor.blockhound;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/agent/src/main/java/reactor/blockhound/integration/BlockHoundIntegration.java
+++ b/agent/src/main/java/reactor/blockhound/integration/BlockHoundIntegration.java
@@ -16,7 +16,7 @@
 
 package reactor.blockhound.integration;
 
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 
 public interface BlockHoundIntegration extends Comparable<BlockHoundIntegration> {
 

--- a/agent/src/main/java/reactor/blockhound/integration/LoggingIntegration.java
+++ b/agent/src/main/java/reactor/blockhound/integration/LoggingIntegration.java
@@ -17,7 +17,7 @@
 package reactor.blockhound.integration;
 
 import com.google.auto.service.AutoService;
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 
 @AutoService(BlockHoundIntegration.class)
 public class LoggingIntegration implements BlockHoundIntegration {

--- a/agent/src/main/java/reactor/blockhound/integration/ReactorIntegration.java
+++ b/agent/src/main/java/reactor/blockhound/integration/ReactorIntegration.java
@@ -17,7 +17,7 @@
 package reactor.blockhound.integration;
 
 import com.google.auto.service.AutoService;
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 import reactor.core.scheduler.NonBlocking;
 import reactor.core.scheduler.Schedulers;
 import reactor.blockhound.integration.util.TaskWrappingScheduledExecutorService;

--- a/agent/src/main/java/reactor/blockhound/integration/RxJava2Integration.java
+++ b/agent/src/main/java/reactor/blockhound/integration/RxJava2Integration.java
@@ -20,7 +20,7 @@ import com.google.auto.service.AutoService;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.schedulers.NonBlockingThread;
 import io.reactivex.plugins.RxJavaPlugins;
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 
 @AutoService(BlockHoundIntegration.class)
 public class RxJava2Integration implements BlockHoundIntegration {

--- a/docs/how_it_works.md
+++ b/docs/how_it_works.md
@@ -10,7 +10,7 @@ To detect blocking Java methods, BlockHound alters the bytecode of a method and 
 ```java
 // java.net.Socket
 public void connect(SocketAddress endpoint, int timeout) {
-    reactor.BlockHoundRuntime.checkBlocking(
+    reactor.blockhound.BlockHoundRuntime.checkBlocking(
         "java.net.Socket",
         "connect",
         /*method modifiers*/
@@ -47,7 +47,7 @@ As you can see, the cost of such instrumentation is minimal and only adds 1 hop 
 Now, we add the blocking call detection, the same way as we do it with Java methods:
 ```java
 public static void sleep(long millis) {
-    reactor.BlockHoundRuntime.checkBlocking(
+    reactor.blockhound.BlockHoundRuntime.checkBlocking(
         "java.lang.Thread",
         "sleep",
         /*method modifiers*/

--- a/example/src/test/java/com/example/BuilderTest.java
+++ b/example/src/test/java/com/example/BuilderTest.java
@@ -17,7 +17,7 @@
 package com.example;
 
 import org.junit.Test;
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 

--- a/example/src/test/java/com/example/FalseNegativesTest.java
+++ b/example/src/test/java/com/example/FalseNegativesTest.java
@@ -20,7 +20,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 

--- a/example/src/test/java/com/example/ReactorTest.java
+++ b/example/src/test/java/com/example/ReactorTest.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;

--- a/example/src/test/java/com/example/RxJavaTest.java
+++ b/example/src/test/java/com/example/RxJavaTest.java
@@ -20,7 +20,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.exceptions.CompositeException;
 import org.junit.Test;
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.TimeUnit;

--- a/junit-platform/src/main/java/reactor/blockhound/junit/platform/BlockHoundTestExecutionListener.java
+++ b/junit-platform/src/main/java/reactor/blockhound/junit/platform/BlockHoundTestExecutionListener.java
@@ -2,7 +2,7 @@ package reactor.blockhound.junit.platform;
 
 import com.google.auto.service.AutoService;
 import org.junit.platform.launcher.TestExecutionListener;
-import reactor.BlockHound;
+import reactor.blockhound.BlockHound;
 
 @AutoService(TestExecutionListener.class)
 public class BlockHoundTestExecutionListener implements TestExecutionListener {

--- a/native-agent/src/main/cpp/agent.cpp
+++ b/native-agent/src/main/cpp/agent.cpp
@@ -42,7 +42,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *) {
     return JNI_VERSION_1_8;
 }
 
-extern "C" JNIEXPORT void JNICALL Java_reactor_BlockHoundRuntime_markMethod(JNIEnv *env, jobject, jclass clazz, jstring hookMethodName, jboolean allowed) {
+extern "C" JNIEXPORT void JNICALL Java_reactor_blockhound_BlockHoundRuntime_markMethod(JNIEnv *env, jobject, jclass clazz, jstring hookMethodName, jboolean allowed) {
     const char *hookMethodChars = env->GetStringUTFChars(hookMethodName, JNI_FALSE);
 
     jint methodCount;
@@ -63,7 +63,7 @@ extern "C" JNIEXPORT void JNICALL Java_reactor_BlockHoundRuntime_markMethod(JNIE
     }
 }
 
-extern "C" JNIEXPORT jboolean JNICALL Java_reactor_BlockHoundRuntime_isBlocking(JNIEnv *env) {
+extern "C" JNIEXPORT jboolean JNICALL Java_reactor_blockhound_BlockHoundRuntime_isBlocking(JNIEnv *env) {
     jthread thread;
     jvmti->GetCurrentThread(&thread);
 
@@ -81,7 +81,7 @@ extern "C" JNIEXPORT jboolean JNICALL Java_reactor_BlockHoundRuntime_isBlocking(
         // Since we call back into Java code, it might call a blocking method.
         // However, since "isNonBlocking" is false by default,
         // it should be safe and not create a recursion problem.
-        jclass runtimeClass = env->FindClass("Lreactor/BlockHoundRuntime;");
+        jclass runtimeClass = env->FindClass("Lreactor/blockhound/BlockHoundRuntime;");
         jmethodID isBlockingThreadMethodId = env->GetStaticMethodID(runtimeClass, "isBlockingThread", "(Ljava/lang/Thread;)Z");
         t->isNonBlocking = env->CallStaticBooleanMethod(runtimeClass, isBlockingThreadMethodId, thread) == JNI_TRUE;
     }


### PR DESCRIPTION
To be more Jigsaw friendly, we should clearly define the top level package for each Reactor's sub-project.
`reactor.BlockHound` class breaks this, and should be moved to a dedicated package (`reactor.blockhound`)

See https://github.com/reactor/reactor/issues/667