### PR TITLE
Skip `ReactorIntegration` on Reactor 3.3.x since it got a built-in one

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -41,10 +41,6 @@ task relocateShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.Co
 
 tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
-repositories {
-    jcenter()
-}
-
 dependencies {
     compileOnly 'com.google.auto.service:auto-service:1.0-rc4'
 

--- a/agent/src/main/java/reactor/blockhound/integration/ReactorIntegration.java
+++ b/agent/src/main/java/reactor/blockhound/integration/ReactorIntegration.java
@@ -37,6 +37,14 @@ public class ReactorIntegration implements BlockHoundIntegration {
             return;
         }
 
+        try {
+            // Reactor 3.3.x comes with built-in integration
+            Class.forName("reactor.core.CorePublisher");
+            return;
+        }
+        catch (ClassNotFoundException ignored) {
+        }
+
         // `ScheduledThreadPoolExecutor$DelayedWorkQueue.offer` parks the Thread with Unsafe#park.
         builder.allowBlockingCallsInside(ScheduledThreadPoolExecutor.class.getName(), "scheduleAtFixedRate");
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id "java"
 }
 
+repositories {
+    maven { url 'https://repo.spring.io/libs-snapshot' }
+}
 
 test {
     dependsOn(tasks.getByPath(":agent:shadowJar"))
@@ -16,6 +19,22 @@ test {
     jvmArgs = ["-Xverify:all"]
 }
 
+configurations {
+    reactor_3_3_x {
+        extendsFrom(testCompile, testRuntime)
+    }
+}
+
+task testReactor3_3_x(type: Test) {
+    group = 'verification'
+
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.output.classesDirs + configurations.reactor_3_3_x
+
+    include 'com/example/ReactorTest**'
+}
+check.dependsOn(testReactor3_3_x)
+
 dependencies {
     testCompile project(path: ":agent", configuration: 'shadow')
     testCompile 'io.projectreactor:reactor-core:3.2.2.RELEASE'
@@ -23,4 +42,6 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:3.11.1'
+
+    reactor_3_3_x 'io.projectreactor:reactor-core:3.3.0.BUILD-SNAPSHOT'
 }


### PR DESCRIPTION
Since https://github.com/reactor/reactor-core/pull/1682 is merged now, we should not instrument Reactor because it natively integrates with BlockHound via the SPI