### PR TITLE
Fix custom blocking methods

### DIFF
--- a/agent/src/main/java/reactor/blockhound/ASMClassFileTransformer.java
+++ b/agent/src/main/java/reactor/blockhound/ASMClassFileTransformer.java
@@ -36,7 +36,7 @@ import static org.objectweb.asm.Opcodes.*;
  */
 class ASMClassFileTransformer implements ClassFileTransformer {
 
-    private static final Type BLOCK_HOUND_RUNTIME_TYPE = Type.getType(BlockHoundRuntime.class);
+    private static final Type BLOCK_HOUND_RUNTIME_TYPE = Type.getType("Lreactor/blockhound/BlockHoundRuntime;");
 
     private static final Method CHECK_BLOCKING_METHOD = new Method(
             "checkBlocking",

--- a/agent/src/main/java/reactor/blockhound/ASMClassFileTransformer.java
+++ b/agent/src/main/java/reactor/blockhound/ASMClassFileTransformer.java
@@ -36,7 +36,7 @@ import static org.objectweb.asm.Opcodes.*;
  */
 class ASMClassFileTransformer implements ClassFileTransformer {
 
-    private static final Type BLOCK_HOUND_RUNTIME_TYPE = Type.getType("Lreactor/blockhound/BlockHoundRuntime;");
+    static final Type BLOCK_HOUND_RUNTIME_TYPE = Type.getType("Lreactor/blockhound/BlockHoundRuntime;");
 
     private static final Method CHECK_BLOCKING_METHOD = new Method(
             "checkBlocking",

--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -157,7 +157,7 @@ public class BlockHound {
         private Predicate<Thread> threadPredicate = t -> false;
 
         public Builder markAsBlocking(Class clazz, String methodName, String signature) {
-            return markAsBlocking(clazz.getCanonicalName(), methodName, signature);
+            return markAsBlocking(clazz.getName(), methodName, signature);
         }
 
         public Builder markAsBlocking(String className, String methodName, String signature) {
@@ -213,12 +213,12 @@ public class BlockHound {
 
                 Instrumentation instrumentation = ByteBuddyAgent.install();
 
-                InstrumentationUtils.injectBootstrapClasses(instrumentation, BlockHoundRuntime.class);
+                InstrumentationUtils.injectBootstrapClasses(instrumentation, "reactor/blockhound/BlockHoundRuntime");
 
                 final Class<?> runtimeClass;
                 final Method initMethod;
                 try {
-                    runtimeClass = ClassLoader.getSystemClassLoader().getParent().loadClass(BlockHoundRuntime.class.getCanonicalName());
+                    runtimeClass = ClassLoader.getSystemClassLoader().getParent().loadClass("reactor.blockhound.BlockHoundRuntime");
                     initMethod = runtimeClass.getMethod("init", String.class);
                 }
                 catch (Throwable e) {
@@ -275,11 +275,11 @@ public class BlockHound {
                             .of(instrumentation.getAllLoadedClasses())
                             .filter(it -> {
                                 try {
-                                    String canonicalName = it.getCanonicalName();
-                                    if (canonicalName == null) {
+                                    String className = it.getName();
+                                    if (className == null) {
                                         return false;
                                     }
-                                    return blockingMethods.containsKey(canonicalName.replace(".", "/"));
+                                    return blockingMethods.containsKey(className.replace(".", "/"));
                                 }
                                 catch (NoClassDefFoundError e) {
                                     return false;

--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.Collections.singleton;
+import static reactor.blockhound.ASMClassFileTransformer.BLOCK_HOUND_RUNTIME_TYPE;
 
 public class BlockHound {
 
@@ -213,12 +214,12 @@ public class BlockHound {
 
                 Instrumentation instrumentation = ByteBuddyAgent.install();
 
-                InstrumentationUtils.injectBootstrapClasses(instrumentation, "reactor/blockhound/BlockHoundRuntime");
+                InstrumentationUtils.injectBootstrapClasses(instrumentation, BLOCK_HOUND_RUNTIME_TYPE.getInternalName());
 
                 final Class<?> runtimeClass;
                 final Method initMethod;
                 try {
-                    runtimeClass = ClassLoader.getSystemClassLoader().getParent().loadClass("reactor.blockhound.BlockHoundRuntime");
+                    runtimeClass = ClassLoader.getSystemClassLoader().getParent().loadClass(BLOCK_HOUND_RUNTIME_TYPE.getClassName());
                     initMethod = runtimeClass.getMethod("init", String.class);
                 }
                 catch (Throwable e) {

--- a/agent/src/main/java/reactor/blockhound/BlockHoundRuntime.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHoundRuntime.java
@@ -19,6 +19,9 @@ package reactor.blockhound;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+// Warning!!! This class MUST NOT be loaded by any classloader other than the bootstrap one.
+// Otherwise, non-bootstrap classes will be referring to it, but only the bootstrap one gets
+// initialized and linked to the native library.
 public class BlockHoundRuntime {
 
     @SuppressWarnings("unused")

--- a/agent/src/main/java/reactor/blockhound/InstrumentationUtils.java
+++ b/agent/src/main/java/reactor/blockhound/InstrumentationUtils.java
@@ -27,13 +27,13 @@ import java.util.zip.ZipOutputStream;
 
 class InstrumentationUtils {
 
-    static void injectBootstrapClasses(Instrumentation instrumentation, Class... classes) throws IOException {
+    static void injectBootstrapClasses(Instrumentation instrumentation, String... classNames) throws IOException {
         File tempJarFile = File.createTempFile("BlockHound", ".jar");
 
         ClassLoader classLoader = BlockHound.class.getClassLoader();
         try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(tempJarFile))) {
-            for (Class clazz : classes) {
-                String classFile = clazz.getName().replace(".", "/") + ".class";
+            for (String className : classNames) {
+                String classFile = className.replace(".", "/") + ".class";
                 InputStream inputStream = classLoader.getResourceAsStream(classFile);
                 ZipEntry e = new ZipEntry(classFile);
                 zipOutputStream.putNextEntry(e);

--- a/example/src/test/java/com/example/CustomBlockingMethodTest.java
+++ b/example/src/test/java/com/example/CustomBlockingMethodTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example;
 
 import org.assertj.core.api.Assertions;

--- a/example/src/test/java/com/example/CustomBlockingMethodTest.java
+++ b/example/src/test/java/com/example/CustomBlockingMethodTest.java
@@ -1,0 +1,40 @@
+package com.example;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import reactor.blockhound.BlockHound;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CustomBlockingMethodTest {
+
+    static {
+        // Load the class, so that we test the retransform too
+        Blocking.block();
+        BlockHound.install(b -> {
+            b.markAsBlocking(Blocking.class, "block", "()V");
+        });
+    }
+
+    @Test
+    public void shouldReportCustomBlockingMethods() {
+        Throwable e = Assertions.catchThrowable(() -> {
+            Mono.fromRunnable(Blocking::block).hide().subscribeOn(Schedulers.parallel()).block(Duration.ofMillis(100));
+        });
+
+        assertThat(e)
+                .as("exception")
+                .isNotNull()
+                .hasMessageEndingWith("Blocking call! " + Blocking.class.getName() + ".block");
+    }
+
+    static class Blocking {
+
+        static void block() {
+        }
+    }
+}


### PR DESCRIPTION
1. fix double loading of BlockHoundRuntime class
2. use `Class#getName` instead of `Class#getCanonicalName` (D'oh!)
3. add a test for a non-bootstrap blocking method

Fixes #39