### PR TITLE
Use `ThreadLocal` instead of the tags to store the non-blocking marker

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -5,13 +5,28 @@ plugins {
 
 sourceCompatibility = targetCompatibility = 8
 
+repositories {
+    maven { url 'https://repo.spring.io/libs-milestone' }
+}
+
 jmh {
     jmhVersion = '1.21'
     duplicateClassesStrategy DuplicatesStrategy.INCLUDE
     failOnError = true
+
+    def outputType = "baseline" == project.findProperty("jmhTarget")  ? "jmhBaseline" : "jmh"
+    resultFormat = "text"
+    resultsFile = project.file("${project.buildDir}/reports/${outputType}/result.${resultFormat}")
 }
 
 dependencies {
-    jmh project(path: ":agent", configuration: 'shadow')
+    switch (project.findProperty("jmhTarget")) {
+        case "baseline":
+            jmh 'io.projectreactor.tools:blockhound:1.0.0.M5'
+            break
+        default:
+            jmh project(path: ":agent", configuration: 'shadow')
+    }
+
     jmh "org.openjdk.jmh:jmh-generator-annprocess:1.21"
 }


### PR DESCRIPTION
This PR is a follow up of #35.

Since the non-blocking thread marker is immutable, we could store it in a `ThreadLocal` variable to avoid doing the native code switch.

## Benchmark results
Before:
```
Benchmark                                                Mode  Cnt  Score   Error  Units
BlockHoundBenchmark.measureAllowedBlockingCall           avgt    9  2,878 ± 0,096  us/op
BlockHoundBenchmark.measureBlockingCallInBlockingThread  avgt    9  0,822 ± 0,035  us/op
```

After:
```
Benchmark                                                Mode  Cnt  Score   Error  Units
BlockHoundBenchmark.measureAllowedBlockingCall           avgt    9  2,618 ± 0,095  us/op
BlockHoundBenchmark.measureBlockingCallInBlockingThread  avgt    9  0,510 ± 0,017  us/op
```

Given the baseline of `0,495us/op`, the overhead of doing a blocking call in non-non-blocking thread is now around 3% (`~0,086us/op` aka "86 nanoseconds") and comes from the `ThreadLocal` usage. Which is already a great improvement over 40% overhead of `0,237us/op` of the previous version.