### PR TITLE
Shading is the gift that keeps on giving

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -31,7 +31,7 @@ shadowJar {
     exclude 'reactor/shaded/META-INF/**'
 
     // TODO discuss with ByteBuddy folks how to shade it
-    exclude 'win32-x86*.dll'
+    exclude 'win32-x86*/**'
 }
 
 project.tasks.build.dependsOn(shadowJar)

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -2,9 +2,14 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.3'
     id "java"
     id "maven-publish"
+    id "org.unbroken-dome.test-sets" version "2.2.1"
 }
 
 description = "BlockHound Java Agent"
+
+testSets {
+    jarFileTest
+}
 
 sourceCompatibility = targetCompatibility = 8
 
@@ -18,19 +23,31 @@ shadowJar {
         attributes('Automatic-Module-Name': 'reactor.blockhound')
     }
 
-    exclude 'module-info.class'
+    exclude 'META-INF/versions/9/module-info.class'
+    exclude 'META-INF/LICENSE'
+    exclude 'META-INF/NOTICE'
+    exclude 'META-INF/license/'
     exclude 'META-INF/maven/**'
     exclude 'reactor/shaded/META-INF/**'
+
+    // TODO discuss with ByteBuddy folks how to shade it
+    exclude 'win32-x86*.dll'
 }
 
 project.tasks.build.dependsOn(shadowJar)
 
 task relocateShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation) {
     target = tasks.shadowJar
-    prefix = "reactor.shaded"
+    prefix = "reactor.blockhound.shaded"
 }
 
 tasks.shadowJar.dependsOn tasks.relocateShadowJar
+
+project.tasks.jarFileTest.configure {
+    systemProperty("jarFile", shadowJar.outputs.files.singleFile)
+    dependsOn(shadowJar)
+}
+tasks.check.dependsOn tasks.jarFileTest
 
 dependencies {
     compileOnly 'com.google.auto.service:auto-service:1.0-rc4'
@@ -40,6 +57,9 @@ dependencies {
 
     compileOnly 'io.projectreactor:reactor-core:3.2.5.RELEASE'
     compileOnly 'io.reactivex.rxjava2:rxjava:2.2.5'
+
+    jarFileTestCompile 'org.assertj:assertj-core:3.12.2'
+    jarFileTestCompile 'junit:junit:4.12'
 }
 
 task sourcesJar(type: Jar) {

--- a/agent/src/jarFileTest/java/reactor/blockhoud/AbstractJarFileTest.java
+++ b/agent/src/jarFileTest/java/reactor/blockhoud/AbstractJarFileTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.blockhoud;
+
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * A helper class to access the content of a shaded JAR
+ */
+class AbstractJarFileTest {
+
+	static Path root;
+
+	static {
+		try {
+			Path jarFilePath = Paths.get(System.getProperty("jarFile"));
+			URI jarFileUri = new URI("jar", jarFilePath.toUri().toString(), null);
+			FileSystem fileSystem = FileSystems.newFileSystem(jarFileUri, emptyMap());
+			root = fileSystem.getPath("/");
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/agent/src/jarFileTest/java/reactor/blockhoud/JarFileShadingTest.java
+++ b/agent/src/jarFileTest/java/reactor/blockhoud/JarFileShadingTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.blockhoud;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.assertj.core.api.ListAssert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test must be executed with Gradle because it requires a shadow JAR
+ */
+public class JarFileShadingTest extends AbstractJarFileTest {
+
+	@Test
+	public void testPackages() throws Exception {
+		assertThatFileList(root).containsOnly(
+				"reactor",
+				"META-INF"
+		);
+
+		assertThatFileList(root.resolve("reactor")).containsOnly(
+				"blockhound"
+		);
+	}
+
+	@Test
+	public void testMetaInf() throws Exception {
+		assertThatFileList(root.resolve("META-INF")).containsOnly(
+				"MANIFEST.MF",
+				"services"
+		);
+		assertThatFileList(root.resolve("META-INF").resolve("services")).containsOnly(
+				"reactor.blockhound.integration.BlockHoundIntegration"
+		);
+	}
+
+	private ListAssert<String> assertThatFileList(Path path) throws IOException {
+		return (ListAssert) assertThat(Files.list(path))
+				.extracting(Path::getFileName)
+				.extracting(Path::toString)
+				.extracting(it -> it.endsWith("/") ? it.substring(0, it.length() - 1) : it);
+	}
+
+}


### PR DESCRIPTION
As seen in https://github.com/netty/netty/pull/9687, due to https://github.com/johnrengelman/shadow/issues/519, we have `reactor/shaded/META-INF/versions/9/module-info.class` file in the final JAR, although we thought that we excluded it.

This PR fixes a few related shading issues and adds the missing tests for the shadowed jar, so that we will never miss such issue again.