### PR TITLE
Hide BlockHound's own frame from the Error

### DIFF
--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -206,8 +206,7 @@ public class BlockHound {
 
                 if ("checkBlocking".equals(stackTraceElement.getMethodName())) {
                     if (i + 1 < length) {
-                        System.arraycopy(stackTrace, i + 1, stackTrace, 0, length - i - 1);
-                        error.setStackTrace(stackTrace);
+                        error.setStackTrace(Arrays.copyOfRange(stackTrace, i + 1, length));
                     }
                     break;
                 }

--- a/example/src/test/java/com/example/StackTraceTest.java
+++ b/example/src/test/java/com/example/StackTraceTest.java
@@ -19,6 +19,7 @@ package com.example;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import reactor.blockhound.BlockHound;
+import reactor.blockhound.BlockingOperationError;
 import reactor.core.scheduler.NonBlocking;
 
 import java.util.concurrent.CompletableFuture;
@@ -52,6 +53,7 @@ public class StackTraceTest {
         assertThat(Assertions.catchThrowable(future::join))
                 .as("exception")
                 .isNotNull()
+                .hasCauseInstanceOf(BlockingOperationError.class)
                 .satisfies(e -> {
                     assertThat(e.getCause().getStackTrace())
                             .as("Cause's stacktrace")

--- a/example/src/test/java/com/example/StrackTraceTest.java
+++ b/example/src/test/java/com/example/StrackTraceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import reactor.blockhound.BlockHound;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class StrackTraceTest {
+
+    static {
+        BlockHound.install();
+    }
+
+    @Test
+    public void shouldHideInternalFrames() {
+        Throwable e = Assertions.catchThrowable(() -> {
+            Mono
+                    .fromCallable(() -> {
+                        Thread.sleep(0);
+                        return null;
+                    })
+                    .subscribeOn(Schedulers.parallel())
+                    .block(Duration.ofMillis(100));
+        });
+
+        assertThat(e)
+                .as("exception")
+                .isNotNull()
+                .satisfies(it -> {
+                    assertThat(it.getCause().getStackTrace())
+                            .as("Cause's stacktrace")
+                            .extracting(StackTraceElement::getClassName, StackTraceElement::getMethodName)
+                            .startsWith(
+                                    tuple("java.lang.Thread", "sleep")
+                            );
+                });
+    }
+}


### PR DESCRIPTION
Since we instrument the blocking methods, we add more frames to the stack of the thrown exception. We could artificially remove them from the created `java.lang.Error` instance to not confuse the users with something they do not expect.

**Before:**
```
java.lang.Error: Blocking call! java.lang.Thread.sleep
	at reactor.blockhound.BlockHound$Builder.lambda$new$0(BlockHound.java:196)
	at reactor.blockhound.BlockHound$Builder.lambda$install$6(BlockHound.java:338)
	at reactor.blockhound.BlockHoundRuntime.checkBlocking(BlockHoundRuntime.java:46)
	at java.base/java.lang.Thread.sleep(Thread.java)
	at com.example.StrackTraceTest.lambda$shouldHideInternalFrames$0(StrackTraceTest.java:41)
```

**After:**
```
java.lang.Error: Blocking call! java.lang.Thread.sleep
	at java.base/java.lang.Thread.sleep(Thread.java)
	at com.example.StrackTraceTest.lambda$shouldHideInternalFrames$0(StrackTraceTest.java:41)
```
