### PR TITLE
Clarify RxJava 3+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Although BlockHound supports [the SPI mechanism to integrate with](https://githu
 1. [Project Reactor](https://projectreactor.io)  
   Version 3.2.x is supported out of the box.  
   Starting with `reactor-core` version 3.3.0, there is [a built-in integration in Reactor itself](https://github.com/reactor/reactor-core/blob/v3.3.0.RELEASE/reactor-core/src/main/java/reactor/core/scheduler/ReactorBlockHoundIntegration.java) that uses [the SPI](https://github.com/reactor/BlockHound/blob/master/docs/custom_integrations.md).
-2. [RxJava 2](https://github.com/ReactiveX/RxJava/)
+2. [RxJava 2](https://github.com/ReactiveX/RxJava/) is supported.  
+    RxJava 3 and further versions of RxJava will require an SPI to be implemented, either by the framework or user. See [this PR to RxJava](https://github.com/ReactiveX/RxJava/pull/6692) with an example of the SPI's implementation.
 
 # Quick Start
 See [the docs](./docs/README.md).


### PR DESCRIPTION
Since [RxJava have decided to not accept the BlockHound integration](https://github.com/ReactiveX/RxJava/pull/6692), we should clarify what users of the future versions of RxJava should do to enable BlockHound with RxJava.

If RxJava community decide to add an integration with BlockHound, I will update it accordingly.