### PR TITLE
Add dynamic predicate support (Kotlin, Scala, others)

### DIFF
--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -217,6 +217,8 @@ public class BlockHound {
 
         private Predicate<Thread> threadPredicate = t -> false;
 
+        private Predicate<Thread> dynamicThreadPredicate = t -> false;
+
         /**
          * Marks provided method of the provided class as "blocking".
          *
@@ -304,6 +306,22 @@ public class BlockHound {
         }
 
         /**
+         * Replaces the current dynamic thread predicate with the result of applying the provided function.
+         *
+         * Warning! Consider always using {@link Predicate#or(Predicate)} and not override the previous one:
+         * <code>
+         * dynamicThreadPredicate(current -&gt; current.or(MyMarker.class::isInstance))
+         * </code>
+         *
+         * @param function a function to immediately apply on the current instance of the predicate
+         * @return this
+         */
+        public Builder dynamicThreadPredicate(Function<Predicate<Thread>, Predicate<Thread>> function) {
+            this.dynamicThreadPredicate = function.apply(this.dynamicThreadPredicate);
+            return this;
+        }
+
+        /**
          * Applies the provided {@link BlockHoundIntegration} to the current builder
          * @param integration an integration to apply
          * @return this
@@ -326,7 +344,11 @@ public class BlockHound {
                 }
 
                 Instrumentation instrumentation = ByteBuddyAgent.install();
-                InstrumentationUtils.injectBootstrapClasses(instrumentation, BLOCK_HOUND_RUNTIME_TYPE.getInternalName());
+                InstrumentationUtils.injectBootstrapClasses(
+                        instrumentation,
+                        BLOCK_HOUND_RUNTIME_TYPE.getInternalName(),
+                        "reactor/blockhound/BlockHoundRuntime$State"
+                );
 
                 // Since BlockHoundRuntime is injected into the bootstrap classloader,
                 // we use raw Object[] here instead of `BlockingMethod` to avoid classloading issues
@@ -336,6 +358,10 @@ public class BlockHound {
                     int modifiers = (Integer) args[2];
                     onBlockingMethod.accept(new BlockingMethod(className, methodName, modifiers));
                 };
+
+                // Eagerly trigger the classloading of `dynamicThreadPredicate` (since classloading is blocking)
+                dynamicThreadPredicate.test(Thread.currentThread());
+                BlockHoundRuntime.dynamicThreadPredicate = dynamicThreadPredicate;
 
                 // Eagerly trigger the classloading of `threadPredicate` (since classloading is blocking)
                 threadPredicate.test(Thread.currentThread());

--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -335,6 +335,16 @@ public class BlockHound {
         }
 
         /**
+         * Appends the provided predicate to the current one.
+         *
+         * @param predicate a predicate to append to the current instance of the predicate
+         * @return this
+         */
+        public Builder addDynamicThreadPredicate(Predicate<Thread> predicate) {
+            return dynamicThreadPredicate(p -> p.or(predicate));
+        }
+
+        /**
          * Applies the provided {@link BlockHoundIntegration} to the current builder
          * @param integration an integration to apply
          * @return this

--- a/agent/src/main/java/reactor/blockhound/InstrumentationUtils.java
+++ b/agent/src/main/java/reactor/blockhound/InstrumentationUtils.java
@@ -19,8 +19,6 @@ package reactor.blockhound;
 import net.bytebuddy.jar.asm.ClassReader;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.ClassWriter;
-import net.bytebuddy.jar.asm.FieldVisitor;
-import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 
 import java.io.File;
@@ -72,29 +70,6 @@ class InstrumentationUtils {
         @Override
         public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
             super.visit(version, access | Opcodes.ACC_PUBLIC, name, signature, superName, interfaces);
-        }
-
-        @Override
-        public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
-            switch (name) {
-                case "blockingMethodConsumer":
-                case "threadPredicate":
-                case "IS_ALLOWED":
-                    access = access | Opcodes.ACC_PUBLIC;
-                    break;
-            }
-            return super.visitField(access, name, descriptor, signature, value);
-        }
-
-        @Override
-        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
-            switch (name) {
-                case "checkBlocking":
-                    access = access | Opcodes.ACC_PUBLIC;
-                    break;
-            }
-
-            return super.visitMethod(access, name, descriptor, signature, exceptions);
         }
     }
 }

--- a/example/src/test/java/com/example/DynamicThreadsTest.java
+++ b/example/src/test/java/com/example/DynamicThreadsTest.java
@@ -29,7 +29,7 @@ public class DynamicThreadsTest {
 
     static {
         BlockHound.install(b -> {
-            b.dynamicThreadPredicate(p -> p.or(DynamicThread.class::isInstance));
+            b.addDynamicThreadPredicate(DynamicThread.class::isInstance);
 
             b.nonBlockingThreadPredicate(p -> p.or(thread -> {
                 return thread instanceof DynamicThread && ((DynamicThread) thread).isNonBlocking;

--- a/example/src/test/java/com/example/DynamicThreadsTest.java
+++ b/example/src/test/java/com/example/DynamicThreadsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.junit.Test;
+import reactor.blockhound.BlockHound;
+import reactor.blockhound.BlockingOperationError;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+public class DynamicThreadsTest {
+
+    static {
+        BlockHound.install(b -> {
+            b.dynamicThreadPredicate(p -> p.or(DynamicThread.class::isInstance));
+
+            b.nonBlockingThreadPredicate(p -> p.or(thread -> {
+                return thread instanceof DynamicThread && ((DynamicThread) thread).isNonBlocking;
+            }));
+        });
+    }
+
+    @Test
+    public void shouldNotCacheDynamicThreads() throws Exception {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        DynamicThread thread = new DynamicThread() {
+            @Override
+            public void run() {
+                try {
+                    try {
+                        isNonBlocking = true;
+                        Thread.sleep(0);
+                        fail("should fail");
+                    }
+                    catch (BlockingOperationError ignored) {
+                    }
+
+                    isNonBlocking = false;
+                    Thread.sleep(0);
+
+                    try {
+                        isNonBlocking = true;
+                        Thread.sleep(0);
+                        fail("should fail");
+                    }
+                    catch (BlockingOperationError ignored) {
+                    }
+
+                    future.complete(null);
+                }
+                catch (Throwable e) {
+                    future.completeExceptionally(e);
+                }
+            }
+        };
+
+        thread.start();
+
+        future.get(5, TimeUnit.SECONDS);
+    }
+
+    static class DynamicThread extends Thread {
+
+        boolean isNonBlocking = true;
+    }
+}


### PR DESCRIPTION
At S1P, we discussed with @elizarov the possibility of adding BlockHound integration to Kotlin:
https://github.com/Kotlin/kotlinx.coroutines/issues/1031

One of the major blockers was a lack of an API to dynamically decide whether thread is blocking or non-blocking since, in Kotlin, they change it dynamically.

This PR adds a new API to mark thread as "dynamic", which means that the blocking check should call `threadPredicate` once again before reporting the blocking call.

Example usage:
```java
b.dynamicThreadPredicate(p -> p.or(DynamicThread.class::isInstance));

b.nonBlockingThreadPredicate(p -> p.or(thread -> {
    return thread instanceof DynamicThread && ((DynamicThread) thread).isNonBlocking;
}));
```

where `DynamicThread#isNonBlocking` is a field that reflects the current "mode".