### PR TITLE
Use `getInternalName()` instead of `getName()`

### DIFF
--- a/agent/src/main/java/reactor/blockhound/AllowancesByteBuddyTransformer.java
+++ b/agent/src/main/java/reactor/blockhound/AllowancesByteBuddyTransformer.java
@@ -60,7 +60,7 @@ class AllowancesByteBuddyTransformer implements AgentBuilder.Transformer {
                 .withCustomMapping()
                 .bind(new AllowedArgument.Factory(methods))
                 .to(AllowAdvice.class)
-                .on(method -> methods.containsKey(method.getName()));
+                .on(method -> methods.containsKey(method.getInternalName()));
 
         return builder.visit(advice);
     }
@@ -94,7 +94,7 @@ class AllowancesByteBuddyTransformer implements AgentBuilder.Transformer {
                     AdviceType adviceType
             ) {
                 return (instrumentedType, instrumentedMethod, assigner, argumentHandler, sort) -> {
-                    boolean allowed = methods.get(instrumentedMethod.getName());
+                    boolean allowed = methods.get(instrumentedMethod.getInternalName());
                     return Advice.OffsetMapping.Target.ForStackManipulation.of(allowed);
                 };
             }

--- a/agent/src/main/java/reactor/blockhound/BlockingCallsByteBuddyTransformer.java
+++ b/agent/src/main/java/reactor/blockhound/BlockingCallsByteBuddyTransformer.java
@@ -61,7 +61,7 @@ class BlockingCallsByteBuddyTransformer implements AgentBuilder.Transformer {
                 .bind(ModifiersArgument.Factory.INSTANCE)
                 .to(BlockingCallAdvice.class)
                 .on(method -> {
-                    Set<String> descriptors = methods.get(method.getName());
+                    Set<String> descriptors = methods.get(method.getInternalName());
                     return descriptors != null && descriptors.contains(method.getDescriptor());
                 });
 

--- a/example/src/test/java/com/example/StaticInitTest.java
+++ b/example/src/test/java/com/example/StaticInitTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.junit.Test;
+import reactor.blockhound.BlockHound;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+public class StaticInitTest {
+
+    static {
+        BlockHound.install(b -> {
+            b.allowBlockingCallsInside(ClassWithStaticInit.class.getName(), "<clinit>");
+        });
+    }
+
+    @Test
+    public void shouldInstrumentStaticInitializers() {
+        Mono.fromCallable(ClassWithStaticInit::new).subscribeOn(Schedulers.parallel()).block();
+    }
+
+    static class ClassWithStaticInit {
+        static {
+            try {
+                Thread.sleep(0);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
It seems that ByteBuddy's `getName()` returns class' name instead
of `<clinit>` from `getName()`.
This change replaces the usages of `getName()` with `getInternalName()`.

Closes #63.