### PR TITLE
Perform a smoke test after instrumenting the classes.

### DIFF
--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -425,7 +425,8 @@ public class BlockHound {
                 message += "It looks like you're running on JDK 13+.\n";
                 message += "You need to add '-XX:+AllowRedefinitionToAddDeleteMethods' JVM flag.\n";
                 message += "See https://github.com/reactor/BlockHound/issues/33 for more info.";
-            } catch (ClassNotFoundException ignored) {
+            }
+            catch (ClassNotFoundException | NoClassDefFoundError ignored) {
             }
 
             throw new IllegalStateException(message);

--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -361,6 +361,12 @@ public class BlockHound {
          * Installs the agent and runs the instrumentation, but only if BlockHound wasn't installed yet (it is global).
          */
         public void install() {
+            Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    e.printStackTrace();
+                }
+            });
             try {
                 if (!INITIALIZED.compareAndSet(false, true)) {
                     return;

--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -426,7 +426,7 @@ public class BlockHound {
                 message += "You need to add '-XX:+AllowRedefinitionToAddDeleteMethods' JVM flag.\n";
                 message += "See https://github.com/reactor/BlockHound/issues/33 for more info.";
             }
-            catch (ClassNotFoundException | NoClassDefFoundError ignored) {
+            catch (Throwable ignored) {
             }
 
             throw new IllegalStateException(message);

--- a/agent/src/main/java/reactor/blockhound/TestThread.java
+++ b/agent/src/main/java/reactor/blockhound/TestThread.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.blockhound;
+
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This is an internal class for performing the instrumentation test
+ */
+class TestThread extends Thread {
+
+    volatile boolean blockingCallDetected = false;
+
+    final FutureTask<Void> task = new FutureTask<>(() -> {
+        Thread.sleep(0);
+        return null;
+    });
+
+    TestThread() {
+        super();
+        setName("blockhound-test-thread");
+        setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+        task.run();
+    }
+
+    public void startAndWait() {
+        start();
+        try {
+            task.get(5, TimeUnit.SECONDS);
+        }
+        catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Since OpenJDK requires `-XX:+AllowRedefinitionToAddDeleteMethod` (see #33)
starting with Java 13, we should test that the instrumentation
was applied correctly and fail fast if not.