### PR TITLE
Log4j2 Integration

### DIFF
--- a/agent/src/main/java/reactor/blockhound/integration/LoggingIntegration.java
+++ b/agent/src/main/java/reactor/blockhound/integration/LoggingIntegration.java
@@ -35,5 +35,11 @@ public class LoggingIntegration implements BlockHoundIntegration {
             builder.allowBlockingCallsInside("ch.qos.logback.classic.Logger", "callAppenders");
         } catch (ClassNotFoundException e) {
         }
+
+        try {
+            Class.forName("org.apache.logging.log4j.core.config.AppenderControl");
+            builder.allowBlockingCallsInside("org.apache.logging.log4j.core.config.AppenderControl", "callAppender");
+        } catch (ClassNotFoundException e) {
+        }
     }
 }


### PR DESCRIPTION
log4j2 is a very popular logging library and is used by Spring Framework and various projects. LoggingIntegration is missing log4j2 so I had a hard time using BlockHound.

So I'm going to upload this PR to make a simple contribution.

- I couldn't read PR rules in the past, so I PR again after correction(name, email address add).