### PR TITLE
Make BlockingMethod serializable

### DIFF
--- a/agent/src/main/java/reactor/blockhound/BlockingMethod.java
+++ b/agent/src/main/java/reactor/blockhound/BlockingMethod.java
@@ -16,9 +16,11 @@
 
 package reactor.blockhound;
 
+import java.io.Serializable;
+
 import static net.bytebuddy.jar.asm.Opcodes.ACC_STATIC;
 
-public class BlockingMethod {
+public class BlockingMethod implements Serializable {
 
     private final String className;
 


### PR DESCRIPTION
`BlockingMethod` is a field in `BlockingOperationError` and `Error` is serializable. Client-server systems commonly send exceptions around, this exception fails to serialize.