### PR TITLE
Fix the pom: no module metadata, fix name and description

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 description = "BlockHound Java Agent"
+ext.detailedDescription = "Java agent to detect blocking calls from non-blocking threads."
 
 testSets {
     jarFileTest

--- a/build.gradle
+++ b/build.gradle
@@ -29,4 +29,8 @@ subprojects {
             }
         }
     }
+
+    tasks.withType(GenerateModuleMetadata) {
+        enabled = false
+    }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -3,8 +3,10 @@ plugins.withType(MavenPublishPlugin) {
         publications {
             mavenJava(MavenPublication) { publication ->
                 pom {
+                    afterEvaluate {
+                        name = project.description ?: "BlockHound"
+                    }
                     description = 'Java agent to detect blocking calls from non-blocking threads.'
-                    name = project.description ?: description
                     url = 'https://github.com/reactor/BlockHound'
                     licenses {
                         license {

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -4,9 +4,9 @@ plugins.withType(MavenPublishPlugin) {
             mavenJava(MavenPublication) { publication ->
                 pom {
                     afterEvaluate {
-                        name = project.description ?: "BlockHound"
+                        name = project.description
+                        description = project.detailedDescription
                     }
-                    description = 'Java agent to detect blocking calls from non-blocking threads.'
                     url = 'https://github.com/reactor/BlockHound'
                     licenses {
                         license {

--- a/junit-platform/build.gradle
+++ b/junit-platform/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 description = "BlockHound JUnit Platform Integration"
+ext.detailedDescription = "Integrates the BlockHound Java agent to detect blocking calls in JUnit Platform-based tests."
 
 sourceCompatibility = targetCompatibility = 8
 


### PR DESCRIPTION
Since the switch to more recent version of Gradle, two issues have been introduced in the pom:
 1. the `name` is wrong (doesn't pick up `project.description` from each submodule) - should be fixed by deferring the evaluation of `project.description` using `afterEvaluate` closure
 2. the junit-platform submodule publishes module file, while agent doesn't - for now we'll avoid generating the module metadata file by disabling the relevant tasks