### PR TITLE
Deploy releases to SonatypeOSS (staging repo) instead of Bintray

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,13 @@ jobs:
           java-version: 8
       - name: Publish Release
         if: endsWith(github.event.release.tag_name, '.RELEASE')
-        run: ./gradlew --no-daemon -Pversion="${{github.event.release.tag_name}}" publish
+        run: ./gradlew --no-daemon -Pversion="${{github.event.release.tag_name}}" sign publish
         env:
-          GRADLE_PUBLISH_REPO_URL: https://api.bintray.com/maven/spring/jars/BlockHound/
-          GRADLE_PUBLISH_MAVEN_USER: ${{secrets.BINTRAY_USER}}
-          GRADLE_PUBLISH_MAVEN_PASSWORD: ${{secrets.BINTRAY_API_KEY}}
+          GRADLE_PUBLISH_REPO_URL: https://s01.oss.sonatype.org/service/local/staging/deploy/maven2
+          GRADLE_PUBLISH_MAVEN_USER: ${{secrets.MAVEN_USER}}
+          GRADLE_PUBLISH_MAVEN_PASSWORD: ${{secrets.MAVEN_PASSWORD}}
+          GRADLE_SIGNING_KEY: ${{secrets.SIGNING_KEY}}
+          GRADLE_SIGNING_PASSWORD: ${{secrets.SIGNING_PASSPHRASE}}
       - name: Publish Milestone
         if: github.event.release.prerelease && (contains(github.event.release.tag_name, '.M') || contains(github.event.release.tag_name, '.RC'))
         run: ./gradlew --no-daemon -Pversion="${{github.event.release.tag_name}}" publish

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '6.1.0'
     id "java"
     id "maven-publish"
+    id "signing"
     id "org.unbroken-dome.test-sets" version "3.0.1"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,27 @@ subprojects {
         }
     }
 
+
+    plugins.withType(SigningPlugin) {
+        //skipping if not .RELEASE. Note the task graph is still being evaluated here.
+        //This works because the version is only defined by CI scripts, and only the release one should use .RELEASE suffix
+        def shouldSign = version.toString().endsWith(".RELEASE")
+        project.signing {
+            required { shouldSign }
+
+            //skip the configuration entirely if !shouldSign. the task shouldn't even be available
+            if (shouldSign) {
+                def signingKey = System.getenv('GRADLE_SIGNING_KEY')
+                def signingPassword = System.getenv('GRADLE_SIGNING_PASSWORD')
+                useInMemoryPgpKeys(signingKey, signingPassword)
+
+                afterEvaluate {
+                    sign publishing.publications.mavenJava
+                }
+            }
+        }
+    }
+
     plugins.withType(MavenPublishPlugin) {
         project.publishing {
             repositories {

--- a/junit-platform/build.gradle
+++ b/junit-platform/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "maven-publish"
+    id "signing"
 }
 
 description = "BlockHound JUnit Platform Integration"


### PR DESCRIPTION
This commit switches the target of GA release deployments from Bintray
to Sonatype OSS / Maven Central (triggering the creation of a staging
repository, but not the closure and promotion of said repository).

This will ensure releases can be performed past Bintray's sunset.

Since Maven Central requires signed artifacts, the `signing` plugin is
added to the mix. As a core Gradle plugin, it is trusted enough to have
access to the relevant secrets.

This change also relies on the `release` environment in GitHub having
additional secrets (GPG signing key+passphrase, Sonatype credentials).
