### PR TITLE
Ensure junit-platform has compile dep to blockhound in pom

### DIFF
--- a/junit-platform/build.gradle
+++ b/junit-platform/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java-library" //historically publishes blockhound as compile dependency in pom
+    id "java-library"
     id "maven-publish"
     id "signing"
 }
@@ -24,6 +24,7 @@ dependencies {
     compileOnly 'com.google.auto.service:auto-service-annotations:1.0-rc7'
     annotationProcessor 'com.google.auto.service:auto-service:1.0-rc7'
 
+    //the api configuration ensures we publish blockhound at compile scope in pom
     api project(path: ":agent", configuration: 'shadow')
 
     compileOnly 'org.junit.platform:junit-platform-launcher:1.0.0'

--- a/junit-platform/build.gradle
+++ b/junit-platform/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library" //historically publishes blockhound as compile dependency in pom
     id "maven-publish"
     id "signing"
 }
@@ -24,7 +24,7 @@ dependencies {
     compileOnly 'com.google.auto.service:auto-service-annotations:1.0-rc7'
     annotationProcessor 'com.google.auto.service:auto-service:1.0-rc7'
 
-    implementation project(path: ":agent", configuration: 'shadow')
+    api project(path: ":agent", configuration: 'shadow')
 
     compileOnly 'org.junit.platform:junit-platform-launcher:1.0.0'
 


### PR DESCRIPTION
cc @bsideup. If you could locally review and double check all seem in order in generated artifacts, that would be awesome.

if all is good, I'll release 1.0.6.RELEASE next Monday.