### PR TITLE
Replace testCompile with testImplementation in build/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ repositories {
 }
 
 dependencies {
-  testCompile 'io.projectreactor.tools:blockhound:$LATEST_RELEASE'
-  // testCompile 'io.projectreactor.tools:blockhound:$LATEST_MILESTONE'
-  // testCompile 'io.projectreactor.tools:blockhound:$LATEST_SNAPSHOT'
+  testImplementation 'io.projectreactor.tools:blockhound:$LATEST_RELEASE'
+  // testImplementation 'io.projectreactor.tools:blockhound:$LATEST_MILESTONE'
+  // testImplementation 'io.projectreactor.tools:blockhound:$LATEST_SNAPSHOT'
 }
 ```
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -11,9 +11,9 @@ repositories {
 }
 
 dependencies {
-  testCompile 'io.projectreactor.tools:blockhound:$LATEST_RELEASE'
-  // testCompile 'io.projectreactor.tools:blockhound:$LATEST_MILESTONE'
-  // testCompile 'io.projectreactor.tools:blockhound:$LATEST_SNAPSHOT'
+  testImplementation 'io.projectreactor.tools:blockhound:$LATEST_RELEASE'
+  // testImplementation 'io.projectreactor.tools:blockhound:$LATEST_MILESTONE'
+  // testImplementation 'io.projectreactor.tools:blockhound:$LATEST_SNAPSHOT'
 }
 ```
 Where:

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -26,7 +26,7 @@ test {
 
 configurations {
     reactor_3_3_x {
-        extendsFrom(testCompile, testRuntime, testImplementation)
+        extendsFrom(testRuntime, testImplementation)
     }
 }
 


### PR DESCRIPTION
This commit replaces the outdated testCompile Gradle target with its
official replacement, testImplementation. This includes occurrences in
the documentation.

Fixes #234.
