### PR TITLE
Add Premain-Class attribute

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -23,6 +23,7 @@ shadowJar {
         attributes('Can-Set-Native-Method-Prefix': 'true')
         attributes('Can-Redefine-Classes': 'true')
         attributes('Automatic-Module-Name': 'reactor.blockhound')
+        attributes('Premain-Class': 'reactor.blockhound.BlockHound')
     }
 
     exclude 'META-INF/versions/9/module-info.class'

--- a/agent/src/jarFileTest/java/reactor/blockhoud/JarFileShadingTest.java
+++ b/agent/src/jarFileTest/java/reactor/blockhoud/JarFileShadingTest.java
@@ -17,6 +17,7 @@
 package reactor.blockhoud;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -24,6 +25,7 @@ import org.assertj.core.api.ListAssert;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.linesOf;
 
 /**
  * This test must be executed with Gradle because it requires a shadow JAR
@@ -51,6 +53,12 @@ public class JarFileShadingTest extends AbstractJarFileTest {
 		assertThatFileList(root.resolve("META-INF").resolve("services")).containsOnly(
 				"reactor.blockhound.integration.BlockHoundIntegration"
 		);
+	}
+
+	@Test
+	public void testManifest() throws MalformedURLException {
+		assertThat(linesOf(root.resolve("META-INF/MANIFEST.MF").toUri().toURL()))
+				.anyMatch(s -> s.startsWith("Premain-Class: reactor"));
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
This PR adds `premain` method and manifest attribute, supporting the installation of the agent via `-javaagent=` JVM option.