### PR TITLE
Upgrade byte-buddy to version 1.12.21 for support of jdk 18+ versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,36 @@ Where:
 |`$LATEST_MILESTONE`|[![](https://img.shields.io/badge/dynamic/xml.svg?label=&color=blue&query=%2F%2Fmetadata%2Fversioning%2Flatest&url=https%3A%2F%2Frepo.spring.io%2Fmilestone%2Fio%2Fprojectreactor%2Ftools%2Fblockhound%2Fmaven-metadata.xml)](https://repo.spring.io/milestone/io/projectreactor/tools/blockhound/)|
 |`$LATEST_SNAPSHOT`|[![](https://img.shields.io/badge/dynamic/xml.svg?label=&color=orange&query=%2F%2Fmetadata%2Fversioning%2Flatest&url=https%3A%2F%2Frepo.spring.io%2Fsnapshot%2Fio%2Fprojectreactor%2Ftools%2Fblockhound%2Fmaven-metadata.xml)](https://repo.spring.io/snapshot/io/projectreactor/tools/blockhound/)|
 
+## JDK13+ support
+
+for JDK 13+, it is no longer allowed redefining native methods. So for the moment, as a temporary work around, please use the
+`-XX:+AllowRedefinitionToAddDeleteMethods` jvm argument:
+
+_Maven_
+
+```xml
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
+                </configuration>
+    </plugin>
+```
+
+_Gradle_
+
+```groovy
+    tasks.withType(Test).all {
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
+            jvmArgs += [
+                "-XX:+AllowRedefinitionToAddDeleteMethods"
+            ]
+        }
+    }
+```
+
 ## Built-in integrations
 Although BlockHound supports [the SPI mechanism to integrate with](https://github.com/reactor/BlockHound/blob/master/docs/custom_integrations.md), it comes with a few built-in integrations:
 1. [Project Reactor](https://projectreactor.io)  

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     compileOnly 'com.google.auto.service:auto-service-annotations:1.0'
     annotationProcessor 'com.google.auto.service:auto-service:1.0'
 
-    implementation 'net.bytebuddy:byte-buddy:1.12.20'
-    implementation 'net.bytebuddy:byte-buddy-agent:1.12.20'
+    implementation 'net.bytebuddy:byte-buddy:1.12.21'
+    implementation 'net.bytebuddy:byte-buddy-agent:1.12.21'
 
     compileOnly 'io.projectreactor:reactor-core:3.2.5.RELEASE'
     compileOnly 'io.reactivex.rxjava2:rxjava:2.2.18'

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     compileOnly 'com.google.auto.service:auto-service-annotations:1.0'
     annotationProcessor 'com.google.auto.service:auto-service:1.0'
 
-    implementation 'net.bytebuddy:byte-buddy:1.11.19'
-    implementation 'net.bytebuddy:byte-buddy-agent:1.11.19'
+    implementation 'net.bytebuddy:byte-buddy:1.12.20'
+    implementation 'net.bytebuddy:byte-buddy-agent:1.12.20'
 
     compileOnly 'io.projectreactor:reactor-core:3.2.5.RELEASE'
     compileOnly 'io.reactivex.rxjava2:rxjava:2.2.18'

--- a/agent/src/main/java/reactor/blockhound/AllowancesByteBuddyTransformer.java
+++ b/agent/src/main/java/reactor/blockhound/AllowancesByteBuddyTransformer.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.security.ProtectionDomain;
 import java.util.Map;
 
 /**
@@ -48,7 +49,8 @@ class AllowancesByteBuddyTransformer implements AgentBuilder.Transformer {
             DynamicType.Builder<?> builder,
             TypeDescription typeDescription,
             ClassLoader classLoader,
-            JavaModule module
+            JavaModule module,
+            ProtectionDomain protectionDomain
     ) {
         Map<String, Boolean> methods = allowances.get(typeDescription.getName());
 

--- a/agent/src/main/java/reactor/blockhound/BlockingCallsByteBuddyTransformer.java
+++ b/agent/src/main/java/reactor/blockhound/BlockingCallsByteBuddyTransformer.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.security.ProtectionDomain;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,7 +50,8 @@ class BlockingCallsByteBuddyTransformer implements AgentBuilder.Transformer {
             DynamicType.Builder<?> builder,
             TypeDescription typeDescription,
             ClassLoader classLoader,
-            JavaModule module
+            JavaModule module,
+            ProtectionDomain protectionDomain
     ) {
         Map<String, Set<String>> methods = blockingMethods.get(typeDescription.getInternalName());
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -24,6 +24,36 @@ Where:
 |`$LATEST_MILESTONE`|[![](https://img.shields.io/badge/dynamic/xml.svg?label=&color=blue&query=%2F%2Fmetadata%2Fversioning%2Flatest&url=https%3A%2F%2Frepo.spring.io%2Fmilestone%2Fio%2Fprojectreactor%2Ftools%2Fblockhound%2Fmaven-metadata.xml)](https://repo.spring.io/milestone/io/projectreactor/tools/blockhound/)|
 |`$LATEST_SNAPSHOT`|[![](https://img.shields.io/badge/dynamic/xml.svg?label=&color=orange&query=%2F%2Fmetadata%2Fversioning%2Flatest&url=https%3A%2F%2Frepo.spring.io%2Fsnapshot%2Fio%2Fprojectreactor%2Ftools%2Fblockhound%2Fmaven-metadata.xml)](https://repo.spring.io/snapshot/io/projectreactor/tools/blockhound/)|
 
+## JDK13+ support
+
+for JDK 13+, it is no longer allowed redefining native methods. So for the moment, as a temporary work around, please use the
+`-XX:+AllowRedefinitionToAddDeleteMethods` jvm argument:
+
+_Maven_
+
+```xml
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
+                </configuration>
+    </plugin>
+```
+
+_Gradle_
+
+```groovy
+    tasks.withType(Test).all {
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
+            jvmArgs += [
+                "-XX:+AllowRedefinitionToAddDeleteMethods"
+            ]
+        }
+    }
+```
+
 ## Installation
 BlockHound is a JVM agent. You need to "install" it before it starts detecting the issues:
 ```java


### PR DESCRIPTION
This PR is an attempt to add support for JDK 18+ (18, 19, 20), by upgrading byte-buddy to the latest version which is 1.12.20.

Now, there is an incompatible change that has been made in byte-buddy `transform` method of the  `AgentBuilder.Transformer` interface, which is implemented by BlockHound. So, the PR adapts to the new signature of the transform method, which is now taking a `ProtectionDomain`parameter.

Note that you will still need to use the `-XX:+AllowRedefinitionToAddDeleteMethods` when using JDK13+:
For example, when using maven, you can add the following which will make sure tests are run using the flag:

```
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
                <version>2.22.2</version>
                <configuration>
                    <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
                </configuration>
            </plugin>
```

and when using gradle, you can add the following:

```
tasks.withType(Test).all {
    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
        jvmArgs += [
                "-XX:+AllowRedefinitionToAddDeleteMethods"
        ]
    }
}
```

Fixes #291
