### PR TITLE
Updated doc for -javaagent JVM option

### DIFF
--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -94,15 +94,15 @@ public class BlockHound {
     /**
      * Entrypoint for installation via the {@code -javaagent=} command-line option.
      *
-     * @param arg Options for the agent.
-     * @param instrumentation Instrumentation API.
+     * @param agentArgs Options for the agent.
+     * @param inst Instrumentation API.
      *
      * @see java.lang.instrument
      */
-    public static void premain(String arg, Instrumentation instrumentation) {
+    public static void premain(String agentArgs, Instrumentation inst) {
         builder()
                 .loadIntegrations()
-                .with(instrumentation)
+                .with(inst)
                 .install();
     }
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -82,5 +82,12 @@ Mono.delay(Duration.ofMillis(1))
     .block(); // should throw an exception about Thread.sleep
 ```
 
+If you can't change the application code, you can also activate BlockHound using the -javaagent:<path to BlockHound agent jar> JVM option, something like this
+(you need at least version 1.0.7):
+```shell
+java -javaagent:BlockHound/agent/build/libs/agent.jar -jar my-application.jar
+```
+Notice that when using JPMS, for the moment BlockHound needs to be installed using `-javaavant` JVM option.
+
 ## What's Next?
 You can further customize Blockhound's behavior, see [customization](customization.md).


### PR DESCRIPTION
This PR updates the documentation for the new -javaagent JVM option introduced in #297 , and also applies
a cosmetic feedback that has been made in the odl #297 PR.