### PR TITLE
BlockhoundIntegration SPI plugins ordering

### DIFF
--- a/agent/src/main/java/reactor/blockhound/integration/BlockHoundIntegration.java
+++ b/agent/src/main/java/reactor/blockhound/integration/BlockHoundIntegration.java
@@ -37,8 +37,22 @@ public interface BlockHoundIntegration extends Comparable<BlockHoundIntegration>
      */
     void applyTo(BlockHound.Builder builder);
 
+    /**
+     * Returns the default priority level for this integration. The priority level
+     * controls the ordering of the {@link BlockHoundIntegration} plugins.
+     * Plugins which do not provide a priority are sorted using natural ordering, and
+     * their {@link #applyTo(BlockHound.Builder)} method will be called using the order
+     * in which the plugins are loaded.
+     *
+     * @return The {@link BlockHoundIntegration} plugin priority, 0 by default.
+     * @see #compareTo(BlockHoundIntegration) 
+     */
+    default int getPriority() {
+        return 0;
+    }
+
     @Override
     default int compareTo(BlockHoundIntegration o) {
-        return 0;
+        return Integer.compare(getPriority(), o.getPriority());
     }
 }

--- a/example/src/test/java/com/example/IntegrationOrderingTest.java
+++ b/example/src/test/java/com/example/IntegrationOrderingTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.junit.Test;
+import reactor.blockhound.BlockHound;
+import reactor.blockhound.integration.BlockHoundIntegration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * BlockHoundIntegration plugins ordering tests.
+ */
+public class IntegrationOrderingTest {
+
+    final static List<Integer> applied = new ArrayList<>();
+
+    /**
+     * Plugin with priority=-1, loaded from
+     * META-INF/services/reactor.blockhound.integration.BlockHoundIntegration (2nd position in file)
+     */
+    public static final class First implements BlockHoundIntegration {
+
+        public First() {
+            System.out.println("Creating First");
+        }
+        @Override
+        public int getPriority() {
+            return -1;
+        }
+
+        @Override
+        public void applyTo(BlockHound.Builder builder) {
+            applied.add(1);
+        }
+    }
+
+    /**
+     * Plugin with default priority=0, loaded from
+     * META-INF/services/reactor.blockhound.integration.BlockHoundIntegration (1st position in file)
+     */
+    public static final class Second implements BlockHoundIntegration {
+        @Override
+        public void applyTo(BlockHound.Builder builder) {
+            applied.add(2);
+        }
+    }
+
+    /**
+     * Plugin with priority=1, installed using {@link BlockHound#install(BlockHoundIntegration...)}}
+     */
+    public static final class Third implements BlockHoundIntegration {
+        @Override
+        public int getPriority() {
+            return 1;
+        }
+
+        @Override
+        public void applyTo(BlockHound.Builder builder) {
+            applied.add(3);
+        }
+    }
+
+    /**
+     * Plugin with priority=2, installed using {@link BlockHound#install(BlockHoundIntegration...)}}
+     */
+    public static final class Fourth implements BlockHoundIntegration {
+        @Override
+        public int getPriority() {
+            return 2;
+        }
+
+        @Override
+        public void applyTo(BlockHound.Builder builder) {
+            applied.add(4);
+        }
+    }
+
+    /**
+     * Plugin with default priority=0, installed using {@link BlockHound#install(BlockHoundIntegration...)}}
+     */
+    public static final class Fifth implements BlockHoundIntegration {
+        @Override
+        public void applyTo(BlockHound.Builder builder) {
+            applied.add(5);
+        }
+    }
+
+    /**
+     * Plugin with default priority=0, installed using {@link BlockHound#install(BlockHoundIntegration...)}}
+     */
+    public static final class Sixth implements BlockHoundIntegration {
+        @Override
+        public void applyTo(BlockHound.Builder builder) {
+            applied.add(6);
+        }
+    }
+
+    /**
+     * In this test, we install 6 blockhound integrations plugins.
+     * <ul>
+     *     <li> First: priority=-1, defined in META-INF/services/reactor.blockhound.integration.BlockHoundIntegration at 2nd position</li>
+     *     <li> Second: no priority (default=0), defined in META-INF/services/reactor.blockhound.integration.BlockHoundIntegration at 1st position</li>
+     *     <li> Third: priority=1, added using {link {@link BlockHound#install(BlockHoundIntegration...)}}, passed in 2nd parameter</li>
+     *     <li> Fourth: priority=2, added using {link {@link BlockHound#install(BlockHoundIntegration...)}}, passed in 1st parameter</li>
+     *     <li> Fifth: no priority (default=0), added using {link {@link BlockHound#install(BlockHoundIntegration...)}}, passed in 3rd parameter</li>
+     *     <li> Sixth: no priority, by default: 0, added using {link {@link BlockHound#install(BlockHoundIntegration...)}}, passed in 4th parameter</li>
+     * </ul>
+     *
+     * We expect to see the 6 plugins applied in this order: First, Second, Fifth, Sixth, Third, Four.
+     * And plugins without any priority should be loaded in natural order, as before.
+     */
+    @Test
+    public void checkIntegrationsOrdering() {
+        // Do not install BlockHound in our static initialized, because other tests
+        // will load our inner integrations classes ...
+        BlockHound.install(new Fourth(), new Third(), new Fifth(), new Sixth());
+        Integer[] expectedApplies = new Integer[] { 1, 2, 5, 6, 3, 4};
+        assertThat(applied).containsExactly(expectedApplies);
+    }
+}

--- a/example/src/test/java/com/example/IntegrationOrderingTest.java
+++ b/example/src/test/java/com/example/IntegrationOrderingTest.java
@@ -39,8 +39,8 @@ public class IntegrationOrderingTest {
     public static final class First implements BlockHoundIntegration {
 
         public First() {
-            System.out.println("Creating First");
         }
+
         @Override
         public int getPriority() {
             return -1;

--- a/example/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/example/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,0 +1,17 @@
+# 
+#  Copyright (c) 2023-Present Pivotal Software Inc, All Rights Reserved.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#        https://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# 
+com.example.IntegrationOrderingTest$Second
+com.example.IntegrationOrderingTest$First


### PR DESCRIPTION
The BlockHound.loadIntegration() method is intented to control ordering of `BlockhoundIntegration.applyTo` calls with respect to other integrations plugins. So, loadIntegrations() first loads all SPI plugins from META-INF/services, then appends any optional plugins provided in the loadIntegration(...) arguments, and finally sort the list before invoking the plugins applyTo methods.

However, by default, the BlockhoundIntegration.compareTo is implemented like this:

    default int compareTo(BlockHoundIntegration o) {
        return 0;
    }

So, let's say we have these integration plugins being loaded from META-INF/services/... using the BlockHound.loadIntegrations() method:

```java
    public class I1 implements BlockHoundIntegration {
        public void applyTo(BlockHound.Builder builder) {}
    }

    public class I2 implements BlockHoundIntegration {
        public void applyTo(BlockHound.Builder builder) {}
    }
```

Now, let's say one want to install two more SPI integration plugin I3,I4; but ensuring the following: 

- I3 applyTo method must be called after I1, I2 (or I2, I1).
- I4 applyTo method must be called after I3

then one could write this:
```java
    public abstract class OrderedPlugin implements BlockHoundIntegration {
        final int id;

       public OrderedPlugin(int id) {this.id = id;}

        @Override
        public int compareTo(BlockHoundIntegration o) {
            if (o instanceof OrderedPlugin) {
                return Integer.compare(this.id, ((OrderedPlugin) o).id);
            }
            return 1; // always be placed after default plugins
        }
    }

    public class I3 extends OrderedPlugin {
        public I3() { super(1); }

        public void applyTo(BlockHound.Builder builder) {...}
    }

    public class I4 extends OrderedPlugin {
        public I4() { super(2); }

        public void applyTo(BlockHound.Builder builder) {...}
    }
```

The problem is that it does not work because CompareTo method is not transitive: when sorting, if `I1.compareTo(OrderedPlugin)` is called, then 0 is returned, hence we can't really sort the list like we want.

as a work around, you need to programatically install I3, I4, like this: this will ensure that plugins will be applied in desired order: I1, I2, I3, I4, but you then can't declare I3, I4 as SPI plugins.

```java
    BlockHound.install(new I3(), new new I4());
```

now, @johnrengelman suggests a simple patch from #273: in BlockHoundIntegration, introduce a new `getPriority` method that is called by default by the `compareTo` method:

```
public interface BlockHoundIntegration extends Comparable<BlockHoundIntegration> {
    // ...
    default int getPriority() {
        return 0;
    }

    @Override
    default int compareTo(BlockHoundIntegration o) {
        return Integer.compare(getPriority(), o.getPriority());
    }
```

This resolves the issue, and plugins can simply refine the getPriority() method is they want to take control on the order, else ,  by default, plugins applyTo methods will be called in the order on which plugins are loaded (natural ordering).

One thing: in netty, the BlockHound integration is overriding the [compareTo method ](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/Hidden.java#L183), so, for completeness, a PR should be done on netty asking to not override the compareTo method.

Fixes #273 