### PR TITLE
Reuse compatibleVersion project property in benchmark build.gradle

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -22,7 +22,7 @@ jmh {
 dependencies {
     switch (project.findProperty("jmhTarget")) {
         case "baseline":
-            jmh 'io.projectreactor.tools:blockhound:1.0.6.RELEASE'
+            jmh "io.projectreactor.tools:blockhound:${compatibleVersion}"
             break
         default:
             jmh project(path: ":agent", configuration: 'shadow')


### PR DESCRIPTION
When running the benchmark using the baseline (latest release of BlockHound) like this:

```sh
./gradlew --no-daemon benchmarks:jmh -PjmhTarget=baseline 
````

then the baseline version to use is hard coded in the benchmark build.gradle.
Now, for japicmp, we have introduced the baseline version in the gradle.properties (`compatibleVersion`).

Let's reuse this "compatibleVersion" project property from benchmark/gradle.properties, this will make a little bit easier the release process.
