### PR TITLE
Post-release 1.0.7: bump compatibleVersion and BLOCKHOUND_VERSION

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -21,7 +21,7 @@ jobs:
     needs: checkSnapshot
     environment: snapshot
     env: #change this after a release
-      BLOCKHOUND_VERSION: 1.0.7.BUILD-SNAPSHOT
+      BLOCKHOUND_VERSION: 1.0.8.BUILD-SNAPSHOT
     steps:
       - name: check version
         if: ${{ !endsWith(env.BLOCKHOUND_VERSION, '.BUILD-SNAPSHOT') }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-compatibleVersion=1.0.6.RELEASE
+compatibleVersion=1.0.7.RELEASE


### PR DESCRIPTION
Now the 1.0.7.RELEASE version has been published, we need to bump compatibleVersion from gradle.properties, as well as BLOCKHOUND_VERSION from snapshot.yml