### PR TITLE
Revert org.unbroken-dome.test-sets to 4.0.0 version

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "java"
     id "maven-publish"
     id "signing"
-    id "org.unbroken-dome.test-sets" version "4.1.0"
+    id "org.unbroken-dome.test-sets" version "4.0.0"
     id 'me.champeau.gradle.japicmp' version '0.4.2' apply false
     id 'de.undercouch.download' version '5.5.0' apply false    
 }


### PR DESCRIPTION
from PR #374 (where org.unbroken-dome.test-sets was upgraded to 4.1.0 version), the agent project does not build anymore when using java8, we need to revert to 4.0.0 version:

```
A problem occurred configuring project ':agent'.
> Could not resolve all files for configuration ':agent:classpath'.
   > Could not resolve org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:4.1.0.
     Required by:
         project :agent > org.unbroken-dome.test-sets:org.unbroken-dome.test-sets.gradle.plugin:4.1.0
      > No matching variant of org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:4.1.0 was found. The consumer was configured to find a runtime of a library compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '7.6' but:
          - Variant 'apiElements' capability org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:4.1.0 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares an API of a component compatible with Java 11 and the consumer needed a runtime of a component compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6')
          - Variant 'javadocElements' capability org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:4.1.0 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6')
          - Variant 'runtimeElements' capability org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:4.1.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6')
          - Variant 'sourcesElements' capability org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:4.1.0 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6')
```