### PR TITLE
Flag inner `Thread` methods for JDK 19 and greater

### DIFF
--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -134,12 +134,6 @@ public class BlockHound {
     public static class Builder {
 
         private final Map<String, Map<String, Set<String>>> blockingMethods = new HashMap<String, Map<String, Set<String>>>() {{
-            put("java/lang/Thread", new HashMap<String, Set<String>>() {{
-                put("sleep", singleton("(J)V"));
-                put("yield", singleton("()V"));
-                put("onSpinWait", singleton("()V"));
-            }});
-
             put("java/lang/Object", new HashMap<String, Set<String>>() {{
                 put("wait", singleton("(J)V"));
             }});
@@ -217,6 +211,23 @@ public class BlockHound {
                 }});
                 put("java/lang/UNIXProcess", new HashMap<String, Set<String>>() {{
                     put("forkAndExec", singleton("(I[B[B[BI[BI[B[IZ)I"));
+                }});
+            }
+
+            try {
+                // Check if Java 19+
+                Class.forName("java.lang.WrongThreadException");
+
+                put("java/lang/Thread", new HashMap<String, Set<String>>() {{
+                    put("sleep0", singleton("(J)V"));
+                    put("yield0", singleton("()V"));
+                    put("onSpinWait", singleton("()V"));
+                }});
+            } catch (ClassNotFoundException __) {
+                put("java/lang/Thread", new HashMap<String, Set<String>>() {{
+                    put("sleep", singleton("(J)V"));
+                    put("yield", singleton("()V"));
+                    put("onSpinWait", singleton("()V"));
                 }});
             }
         }};

--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/test/java/com/example/BlockingDisallowTest.java
+++ b/example/src/test/java/com/example/BlockingDisallowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2023-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/test/java/com/example/BlockingDisallowTest.java
+++ b/example/src/test/java/com/example/BlockingDisallowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-Present Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/test/java/com/example/BlockingDisallowTest.java
+++ b/example/src/test/java/com/example/BlockingDisallowTest.java
@@ -58,7 +58,7 @@ public class BlockingDisallowTest {
         //given the configuration we expect that Thread.yield() is allowed, but Thread.sleep() inside inner() isn't
         assertThat(boeRef.get())
                 .isNotNull()
-                .hasMessage("Blocking call! java.lang.Thread.sleep")
+                .hasMessageContaining("Blocking call! java.lang.Thread.sleep")
                 .hasStackTraceContaining("at com.example.BlockingDisallowTest$NonBlockingClass.inner")
                 .hasStackTraceContaining("at com.example.BlockingDisallowTest$NonBlockingClass.outer");
     }

--- a/example/src/test/java/com/example/ReactorTest.java
+++ b/example/src/test/java/com/example/ReactorTest.java
@@ -124,14 +124,14 @@ public class ReactorTest {
             });
         });
 
-        tests.put("java.lang.Thread.sleep", () -> {
+        tests.put("java.lang.Thread." + (version.feature() >= 19 ? "sleep0" : "sleep"), () -> {
             return Mono.fromCallable(() -> {
                 Thread.sleep(10);
                 return "";
             });
         });
 
-        tests.put("java.lang.Thread.yield", () -> {
+        tests.put("java.lang.Thread." + (version.feature() >= 19 ? "yield0" : "yield"), () -> {
             return Mono.fromCallable(() -> {
                 Thread.yield();
                 return "";

--- a/example/src/test/java/com/example/ReactorTest.java
+++ b/example/src/test/java/com/example/ReactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/test/java/com/example/ReactorTest.java
+++ b/example/src/test/java/com/example/ReactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Since JDK19, `java.lang.Thread`'s methods have changed to support virtual threads. Specifically, for non-virtual threads, `sleep(long)` invokes `sleep0(long)` and `yield()` invokes `yield0()`. Moreover, since JDK21, `sleep(long, int)` and `sleep(Duration)` directly call `sleep0(long)` as opposed to `sleep(long)`.

Now, to identify all blocking `java.lang.Thread` calls, BlockHound will flag invocations of `sleep0(long)` and `yield0()` as opposed to `sleep(long)` and `yield()` when running on JDK19 or greater.

Fixes #394.