### PR TITLE
Detect jdk major version using Runtime class

### DIFF
--- a/agent/src/main/java/reactor/blockhound/BlockHound.java
+++ b/agent/src/main/java/reactor/blockhound/BlockHound.java
@@ -134,8 +134,6 @@ public class BlockHound {
     public static class Builder {
 
         private final Map<String, Map<String, Set<String>>> blockingMethods = new HashMap<String, Map<String, Set<String>>>() {{
-            int jdkMajorVersion = InstrumentationUtils.getJdkMajorVersion();
-
             put("java/lang/Object", new HashMap<String, Set<String>>() {{
                 put("wait", singleton("(J)V"));
             }});
@@ -196,7 +194,7 @@ public class BlockHound {
                 put("writeBytes", singleton("([BIIZ)V"));
             }});
 
-            if (jdkMajorVersion >= 9) {
+            if (InstrumentationUtils.jdkMajorVersion >= 9) {
                 put("jdk/internal/misc/Unsafe", new HashMap<String, Set<String>>() {{
                     put("park", singleton("(ZJ)V"));
                 }});
@@ -213,7 +211,7 @@ public class BlockHound {
                 }});
             }
 
-            if (jdkMajorVersion < 19) {
+            if (InstrumentationUtils.jdkMajorVersion < 19) {
                 // for jdk version < 19, the native method for Thread.sleep is "sleep"
                 put("java/lang/Thread", new HashMap<String, Set<String>>() {{
                     put("sleep", singleton("(J)V"));
@@ -221,7 +219,7 @@ public class BlockHound {
                     put("onSpinWait", singleton("()V"));
                 }});
             }
-            else if (jdkMajorVersion >= 19 && jdkMajorVersion <= 21) {
+            else if (InstrumentationUtils.jdkMajorVersion >= 19 && InstrumentationUtils.jdkMajorVersion <= 21) {
                 // for jdk version in the range [19, 21], the native method for Thread.sleep is "sleep0"
                 put("java/lang/Thread", new HashMap<String, Set<String>>() {{
                     put("sleep0", singleton("(J)V"));

--- a/agent/src/main/java/reactor/blockhound/NativeWrappingClassFileTransformer.java
+++ b/agent/src/main/java/reactor/blockhound/NativeWrappingClassFileTransformer.java
@@ -36,13 +36,7 @@ class NativeWrappingClassFileTransformer implements ClassFileTransformer {
 
     private final Map<String, Map<String, Set<String>>> blockingMethods;
 
-    public static final boolean IS_JDK_18_OR_NEWER;
-
-    static {
-        String javaVersion = System.getProperty("java.specification.version");
-        double version = Double.parseDouble(javaVersion);
-        IS_JDK_18_OR_NEWER = version >= 18.0;
-    }
+    private static final int JDK_18 = 18;
 
     NativeWrappingClassFileTransformer(final Map<String, Map<String, Set<String>>> blockingMethods) {
         this.blockingMethods = blockingMethods;
@@ -116,7 +110,7 @@ class NativeWrappingClassFileTransformer implements ClassFileTransformer {
                 @Override
                 public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
                     // See #392
-                    if (IS_JDK_18_OR_NEWER && descriptor.equals("Ljdk/internal/vm/annotation/IntrinsicCandidate;")) {
+                    if (InstrumentationUtils.jdkMajorVersion >= JDK_18 && descriptor.equals("Ljdk/internal/vm/annotation/IntrinsicCandidate;")) {
                         return null; // remove the intrinsic annotation
                     }
                     return super.visitAnnotation(descriptor, visible);


### PR DESCRIPTION
in #404 , The `BlockHound` class is detecting the current jdk major version using `InstrumentationUtil.jdkMajorVersion()` method that has been introduced in #404 PR (the new `InstrumentationUtil.jdkMajorVersion()` method is relying on the jdk Runtime.getRuntime() class).

now, there is still another class (`NativeWrappingClassFileTransformer`) which need to determine the current jdk major version. Let's update it in order to reuse the InstrumentationUtil instead of relying of java system properties.