### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
-        java-version: 13
+        java-version: '13'
+        distribution: 'adopt'
     - name: Run tests and javadoc
       run: ./gradlew check javadoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-20.04
     environment: release
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: 8
+          java-version: '8'
+          distribution: 'temurin'
       - name: Publish Release
         if: endsWith(github.event.release.tag_name, '.RELEASE')
         run: ./gradlew --no-daemon -Pversion="${{github.event.release.tag_name}}" sign publish

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,11 +9,12 @@ jobs:
   checkSnapshot:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: 13 # Modern JVM is needed for Java 10+ specific tests
+          java-version: '13' # Modern JVM is needed for Java 10+ specific tests
+          distribution: 'adopt'
       - name: Run tests and javadoc
         run: ./gradlew check javadoc
   publishSnapshot:
@@ -28,11 +29,12 @@ jobs:
         run: |
           echo "::error ::$BLOCKHOUND_VERSION is not following the x.y.z.BUILD-SNAPSHOT format"
           exit 1
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: 8
+          java-version: '8'
+          distribution: 'temurin'
       - name: Publish Snapshot
         run: ./gradlew --no-daemon -Pversion=$BLOCKHOUND_VERSION publish
         env:


### PR DESCRIPTION
Workflows actions are using some deprecated versions, and they also are not using pinned SHA versions.

let's replace the following:

actions/checkout@v1 -> actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 (v4.1.1)
actions/setup-java@v1 -> actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 (v4.2.1)

note: when needing java 13 for setup-java, 'adopt' distribution is used because 'temurin' distribution does not support  java 13.